### PR TITLE
feat: Mount your own rsgain preset file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ LABEL org.label-schema.name="pjmeca/volume-normalizer" \
     org.label-schema.description="This Docker image normalizes the volume of your entire music library using rsgain." \
     org.label-schema.url="https://hub.docker.com/r/pjmeca/volume-normalizer" \
     org.label-schema.vcs-url="https://github.com/pjmeca/volume-normalizer" \
-    org.label-schema.version="1.1.0" \
+    org.label-schema.version="1.2.0" \
     org.label-schema.schema-version="1.0.0-rc.1" \
     org.label-schema.docker.cmd="docker run -d --name volume-normalizer -v /your/main/music/path:/mnt -v /etc/localtime:/etc/localtime:ro -e CRON_SCHEDULE=\"0 4 * * *\" --restart unless-stopped pjmeca/volume-normalizer:latest" \
     maintainer="pjmeca"

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ LABEL org.label-schema.name="pjmeca/volume-normalizer" \
     org.label-schema.vcs-url="https://github.com/pjmeca/volume-normalizer" \
     org.label-schema.version="1.2.0" \
     org.label-schema.schema-version="1.0.0-rc.1" \
-    org.label-schema.docker.cmd="docker run -d --name volume-normalizer -v /your/main/music/path:/mnt -v /etc/localtime:/etc/localtime:ro -e CRON_SCHEDULE=\"0 4 * * *\" --restart unless-stopped pjmeca/volume-normalizer:latest" \
+    org.label-schema.docker.cmd="docker run -d --name volume-normalizer -v /your/main/music/path:/mnt -v /your/preset.ini:/root/.config/rsgain/presets/user_preset.ini:ro -v /etc/localtime:/etc/localtime:ro -e CRON_SCHEDULE=\"0 4 * * *\" --restart unless-stopped pjmeca/volume-normalizer:latest" \
     maintainer="pjmeca"
 WORKDIR /app
 ENV CRON_SCHEDULE="0 */1 * * *"

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ RUN apt-get update && \
     apt install -y --no-install-recommends /tmp/rsgain.deb && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/rsgain.deb
+RUN mkdir -p ~/.config/rsgain/presets && \
+    touch ~/.config/rsgain/presets/user_preset.ini
 COPY start_rsgain.sh start.sh ./
 RUN chmod +x start_rsgain.sh start.sh
 CMD ["./start.sh"]

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ You can find the Dockerfile and all the resources I used to create this image in
 
 ## Usage
 
-The following example creates a container that normalizes your music library everyday at 4 AM.
+The following example creates a container that normalizes your music library everyday at 4 AM. You can define your own presets by mounting a preset file (by default, the `no_album` preset is used).
 
 ### Using docker run:
 
 ```sh
-docker run -d --name volume-normalizer -v /your/main/music/path:/mnt -v /etc/localtime:/etc/localtime:ro -e CRON_SCHEDULE="0 4 * * *" --restart unless-stopped pjmeca/volume-normalizer:latest
+docker run -d --name volume-normalizer -v /your/main/music/path:/mnt -v /your/preset.ini:/root/.config/rsgain/presets/user_preset.ini:ro -v /etc/localtime:/etc/localtime:ro -e CRON_SCHEDULE="0 4 * * *" --restart unless-stopped pjmeca/volume-normalizer:latest
 ```
 
 ### Using docker-compose:
@@ -27,6 +27,7 @@ services:
     container_name: volume-normalizer
     volumes:
       - /your/main/music/path:/mnt # Change this
+      #- /your/preset.ini:/root/.config/rsgain/presets/user_preset.ini:ro # Custom preset
       - /etc/localtime:/etc/localtime:ro
     environment:
       CRON_SCHEDULE: "0 4 * * *" # Customize your cron if needed
@@ -66,13 +67,14 @@ Sleeping until next run.
 Here are some pending ideas that I might try to implement if needed. I am open to suggestions.
 
 - [x] Reduce image size
-- [ ] Optionally pass arguments to rsgain using environment variables
+- [x] ~~Optionally pass arguments to rsgain using environment variables~~ A preset file will be used instead (suggested in [#1](https://github.com/pjmeca/volume-normalizer/issues/1))
 - [ ] Omit previously scanned files (possibly by storing them in a SQLite database)
 
 ## Changelog
 
-- 1.0.0: Initial release
+- 1.2.0: Mount a custom preset file
 - 1.1.0: Reduce Docker image size
+- 1.0.0: Initial release
 
 ## Special Thanks To
 

--- a/docker-compose_build.yml
+++ b/docker-compose_build.yml
@@ -10,6 +10,7 @@ services:
         - linux/amd64
     volumes:
       - /your/main/music/path:/mnt # Change this
+      #- /your/preset.ini:/root/.config/rsgain/presets/user_preset.ini:ro # Custom preset
       - /etc/localtime:/etc/localtime:ro
     environment:
       CRON_SCHEDULE: "* * * * *" # Customize your cron if needed

--- a/docker-compose_release.yml
+++ b/docker-compose_release.yml
@@ -6,6 +6,7 @@ services:
     container_name: volume-normalizer
     volumes:
       - /your/main/music/path:/mnt # Change this
+      #- /your/preset.ini:/root/.config/rsgain/presets/user_preset.ini:ro # Custom preset
       - /etc/localtime:/etc/localtime:ro
     environment:
       CRON_SCHEDULE: "0 4 * * *" # Customize your cron if needed

--- a/start_rsgain.sh
+++ b/start_rsgain.sh
@@ -2,7 +2,13 @@
 
 echo "Starting rsgain..."
 
-/usr/bin/rsgain easy -m MAX -p no_album /mnt
+if [ -s ~/.config/rsgain/presets/user_preset.ini ]; then
+    preset=user_preset
+else
+    preset=no_album
+fi
+
+/usr/bin/rsgain easy -m MAX -p $preset /mnt
 # -m MAX: use max number of threads
 # -p no_album: disable album tags
 


### PR DESCRIPTION
Resolves #1 by binding a new volume: `/your/preset.ini:/root/.config/rsgain/presets/user_preset.ini:ro`. Released under tag [`1.2.0`](https://hub.docker.com/layers/pjmeca/volume-normalizer/1.2.0/images/sha256-c962638ddf1d54c099d267fbb447403d42049bed7b6aa3150ba6e076e344e38a).