### PR TITLE
feat: Customize rsgain arguments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ LABEL org.label-schema.name="pjmeca/volume-normalizer" \
     org.label-schema.vcs-url="https://github.com/pjmeca/volume-normalizer" \
     org.label-schema.version="1.2.0" \
     org.label-schema.schema-version="1.0.0-rc.1" \
-    org.label-schema.docker.cmd="docker run -d --name volume-normalizer -v /your/main/music/path:/mnt -v /your/preset.ini:/root/.config/rsgain/presets/user_preset.ini:ro -v /etc/localtime:/etc/localtime:ro -e CRON_SCHEDULE=\"0 4 * * *\" --restart unless-stopped pjmeca/volume-normalizer:latest" \
+    org.label-schema.docker.cmd="docker run -d --name volume-normalizer -v /your/main/music/path:/mnt -v /your/preset.ini:/root/.config/rsgain/presets/user_preset.ini:ro -v /etc/localtime:/etc/localtime:ro -e CRON_SCHEDULE=\"0 4 * * *\" -e ADDITIONAL_ARGS=\"-S\" --restart unless-stopped pjmeca/volume-normalizer:latest" \
     maintainer="pjmeca"
 WORKDIR /app
 ENV CRON_SCHEDULE="0 */1 * * *"

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ LABEL org.label-schema.name="pjmeca/volume-normalizer" \
     maintainer="pjmeca"
 WORKDIR /app
 ENV CRON_SCHEDULE="0 */1 * * *"
+ENV ADDITIONAL_ARGS=
 COPY --from=download-hcron /usr/local/bin/hcron .
 ARG VERSION=3.5.1 \
     ARCH=amd64

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ You can find the Dockerfile and all the resources I used to create this image in
 
 ## Usage
 
-The following example creates a container that normalizes your music library everyday at 4 AM. You can define your own presets by mounting a preset file (by default, the `no_album` preset is used).
+The following example creates a container that normalizes your music library everyday at 4 AM. You can configure how rsgain behaves by passing arguments via the `ADDITIONAL_ARGS` environment variable and define your own presets by mounting a preset file (by default, the `no_album` preset is used).
 
 ### Using docker run:
 
 ```sh
-docker run -d --name volume-normalizer -v /your/main/music/path:/mnt -v /your/preset.ini:/root/.config/rsgain/presets/user_preset.ini:ro -v /etc/localtime:/etc/localtime:ro -e CRON_SCHEDULE="0 4 * * *" --restart unless-stopped pjmeca/volume-normalizer:latest
+docker run -d --name volume-normalizer -v /your/main/music/path:/mnt -v /your/preset.ini:/root/.config/rsgain/presets/user_preset.ini:ro -v /etc/localtime:/etc/localtime:ro -e CRON_SCHEDULE="0 4 * * *" -e ADDITIONAL_ARGS="-S" --restart unless-stopped pjmeca/volume-normalizer:latest
 ```
 
 ### Using docker-compose:
@@ -31,6 +31,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
     environment:
       CRON_SCHEDULE: "0 4 * * *" # Customize your cron if needed
+      # ADDITIONAL_ARGS: "-S" # Additional arguments
     restart: unless-stopped
 ```
 

--- a/docker-compose_build.yml
+++ b/docker-compose_build.yml
@@ -14,4 +14,5 @@ services:
       - /etc/localtime:/etc/localtime:ro
     environment:
       CRON_SCHEDULE: "* * * * *" # Customize your cron if needed
+      # ADDITIONAL_ARGS: "-S" # Additional arguments
     restart: unless-stopped

--- a/docker-compose_release.yml
+++ b/docker-compose_release.yml
@@ -10,4 +10,5 @@ services:
       - /etc/localtime:/etc/localtime:ro
     environment:
       CRON_SCHEDULE: "0 4 * * *" # Customize your cron if needed
+      # ADDITIONAL_ARGS: "-S" # Additional arguments
     restart: unless-stopped

--- a/start_rsgain.sh
+++ b/start_rsgain.sh
@@ -8,7 +8,7 @@ else
     preset=no_album
 fi
 
-/usr/bin/rsgain easy -m MAX -p $preset /mnt
+/usr/bin/rsgain easy -m MAX -p $preset $ADDITIONAL_ARGS /mnt
 # -m MAX: use max number of threads
 # -p no_album: disable album tags
 


### PR DESCRIPTION
Run rsgain with your own preferences by passing additional arguments via the `ADDITIONAL_ARGS` environment variable.