### PR TITLE
fix: Change line endings from CRLF to LF

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ LABEL org.label-schema.name="pjmeca/volume-normalizer" \
     org.label-schema.description="This Docker image normalizes the volume of your entire music library using rsgain." \
     org.label-schema.url="https://hub.docker.com/r/pjmeca/volume-normalizer" \
     org.label-schema.vcs-url="https://github.com/pjmeca/volume-normalizer" \
-    org.label-schema.version="1.3.0" \
+    org.label-schema.version="1.3.1" \
     org.label-schema.schema-version="1.0.0-rc.1" \
     org.label-schema.docker.cmd="docker run -d --name volume-normalizer -v /your/main/music/path:/mnt -v /your/preset.ini:/root/.config/rsgain/presets/user_preset.ini:ro -v /etc/localtime:/etc/localtime:ro -e CRON_SCHEDULE=\"0 4 * * *\" -e ADDITIONAL_ARGS=\"-S\" --restart unless-stopped pjmeca/volume-normalizer:latest" \
     maintainer="pjmeca"

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Here are some pending ideas that I might try to implement if needed. I am open t
 
 ## Changelog
 
+- 1.3.1: Fix line endings from CRLF to LF
 - 1.3.0
   - Upgrade rsgain to v3.5.1
   - Customize rsgain arguments


### PR DESCRIPTION
This change was only made on my machine for building and pushing the image to Docker Hub, as Git automatically committed files using LF.